### PR TITLE
Compatibility with .zen folder along with checking whether profile is valid along with a few small changes.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,7 +20,7 @@ def get_profiles(_args):
         print('No profiles available.')
         return
 
-    print('Available profiles:')
+    print('\nAvailable profiles:')
 
     for profile in zen_profiles:
         profile_id, profile_name = profile.split('.', 1)
@@ -45,7 +45,7 @@ def themes(args):
     if len(args) > 0:
         try:
             page = int(args[0])
-        except:
+        except Exception:
             pass
     if not repository.data or not repository.data.themes:
         print('No themes available.')
@@ -55,7 +55,7 @@ def themes(args):
     if page > maxpage:
         page = maxpage
 
-    print('Available themes')
+    print('\nAvailable themes')
     theme_names = list(repository.data.themes.keys())
     for x in range(page * 20, min((page + 1) * 20, len(theme_names))):
         if x >= len(theme_names):

--- a/zen_explorer_core/profiles.py
+++ b/zen_explorer_core/profiles.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 from pathlib import Path
 
 home = str(Path.home())
@@ -21,12 +22,20 @@ def _get_windows_path():
     return path
 
 def _get_linux_path():
+    zen_path = home + '/.zen'
     path = home + '/.zen/Profiles'
+    
+    if os.path.exists(zen_path):
+        if os.path.exists(path):
+            return path
+        
+        else:
+            if os.path.exists(zen_path):
+                return zen_path
+            
+    raise NotADirectoryError('Zen Browser is not installed')
 
-    if not os.path.exists(path):
-        raise NotADirectoryError('Zen Browser is not installed')
-
-    return path
+    
 
 def _get_flatpak_path():
     path = home + '/.var/app/app.zen_browser.zen/.zen'
@@ -49,7 +58,7 @@ def _get_paths():
         try:
             paths.append(_get_linux_path())
             paths.append(_get_flatpak_path())
-        except:
+        except Exception:
             if not paths:
                 raise
 
@@ -65,13 +74,25 @@ def get_profile_path(profile):
 
 def get_profiles():
     paths = _get_paths()
+    print(f'\nChecking for profiles in {paths}')
+    print(f'path content: {[path for path in paths]}')
     profiles = []
     for path in paths:
         profiles.extend(os.listdir(path))
 
         for profile in profiles:
+            print(f'\nfound possible profile: {profile}')
             # check if profile is a path
-            if not os.path.exists(path + '/' + profile) or profile.startswith('.'):
+            if not os.path.isdir(f'{path}/{profile}') or profile.startswith('.'):
+                print(f'removing invalid profile: {profile}')
                 profiles.remove(profile)
+            else:
+                try: 
+                    profile_id, profile_name = profile.split('.', 1)
+                    print(f'adding valid profile: {profile}')
+                except ValueError:
+                    print(f'There seem to have been a non-profile file or folder inside the profiles directory. Skipping this profile: {profile}.')
+                    profiles.remove(profile)
+                            
 
     return profiles

--- a/zen_explorer_core/repository.py
+++ b/zen_explorer_core/repository.py
@@ -66,3 +66,5 @@ if os.path.isfile(save_dir + '/repository/themes.json'):
         themes = json.load(f)
 
     data = RepositoryData(f'{save_dir}/repository', themes)
+else:
+    print('themes.json not found in repository directory')


### PR DESCRIPTION
# Changes in files
`cli.py`: 
- Small changes to syntax and added `\n` to the start of prints for better readability
---
`profiles.py`: 
- added compatibility for checking whether `~/.zen/` is the profile folder (if `.zen/Profiles` exists, it will be chosen) in `_get_linux_path()`
- Added checking for whether folders/files inside the zen folder are profiles (because in the `.zen` folder there might be other files, too) in `get_profiles()` along with prints for better debugging and/or usage.
---
`repository.py`:
- Added a print for when the `themes.json` file is not found. I shall document this better in the future, as you have to run an update first before themes.json exists. 
